### PR TITLE
Add build targets for GCCLin-x64, GCCLin-x64 Release and GCCWin-x64

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -154,8 +154,8 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
     name="all",
     change_filter=util.ChangeFilter(branch='refs/heads/master'),
     treeStableTimer=None,
-    builderNames=["Build GCCLin_x86", "Build MSVC_x86", "Build MSVC_x64"]))
-    #builderNames=["Build GCCLin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK"]))
+    builderNames=["Build GCCLin_x86", "Build GCCLin_x64", "Build MSVC_x86", "Build MSVC_x64"]))
+    #builderNames=["Build GCCLin_x86", "Build GCCLin_x64", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK"]))
 
 c['schedulers'].append(schedulers.SingleBranchScheduler(
     name="rostests",
@@ -178,7 +178,7 @@ c['schedulers'].append(schedulers.Triggerable(
 
 c['schedulers'].append(schedulers.Periodic(
     name="Daily",
-    builderNames=["Build GCCLin_x86 Release", "Build GCCWin_x86"],
+    builderNames=["Build GCCLin_x86 Release", "Build GCCLin_x64 Release", "Build GCCWin_x86", "Build GCCWin_x64"],
     periodicBuildTimer=24*60*60))
 
 c['schedulers'].append(schedulers.ForceScheduler(
@@ -188,8 +188,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
     properties=[util.NestedParameter("", fields=[
         util.StringParameter(name="id", label="JIRA Patch ID:")
     ])],
-    builderNames=["Build GCCLin_x86", "Build GCCWin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test WHS"]))
-    #builderNames=["Build GCCLin_x86", "Build GCCWin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK", "Test WHS"]))
+    builderNames=["Build GCCLin_x86", "Build GCCLin_x64", "Build GCCWin_x86", "Build GCCWin_x64", "Build MSVC_x86", "Build MSVC_x64", "Test WHS"]))
+    #builderNames=["Build GCCLin_x86", "Build GCCLin_x64", "Build GCCWin_x86", "Build GCCWin_x64", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK", "Test WHS"]))
 
 ####### BUILDERS
 
@@ -249,6 +249,18 @@ Build_GCCLin_x86.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_r
 Build_GCCLin_x86.addStep(steps.Trigger(schedulerNames=['Carrier Testbot Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
 Build_GCCLin_x86.addStep(bs_upload_iso)
 
+Build_GCCLin_x64 = util.BuildFactory();
+Build_GCCLin_x64.addStep(bs_clean)
+Build_GCCLin_x64.addStep(bs_git)
+Build_GCCLin_x64.addStep(bs_prepare_source)
+Build_GCCLin_x64.addStep(make_bs_configure("-DARCH=amd64"))
+Build_GCCLin_x64.addStep(bs_bootcd)
+Build_GCCLin_x64.addStep(bs_livecd)
+Build_GCCLin_x64.addStep(steps.Compile(name="regtestcd", command=["bash", scripts_root + "regtestcd", "-DENABLE_ROSTESTS=1"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["TestCD"], descriptionDone=["TestCD"]))
+Build_GCCLin_x64.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
+Build_GCCLin_x64.addStep(steps.Trigger(schedulerNames=['Carrier Testbot-x64 Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
+Build_GCCLin_x64.addStep(bs_upload_iso)
+
 Build_GCCLin_x86_Release = util.BuildFactory();
 Build_GCCLin_x86_Release.addStep(bs_clean)
 Build_GCCLin_x86_Release.addStep(bs_git)
@@ -258,6 +270,15 @@ Build_GCCLin_x86_Release.addStep(bs_bootcd)
 Build_GCCLin_x86_Release.addStep(bs_livecd)
 Build_GCCLin_x86_Release.addStep(bs_upload_iso)
 
+Build_GCCLin_x64_Release = util.BuildFactory();
+Build_GCCLin_x64_Release.addStep(bs_clean)
+Build_GCCLin_x64_Release.addStep(bs_git)
+Build_GCCLin_x64_Release.addStep(bs_prepare_source)
+Build_GCCLin_x64_Release.addStep(make_bs_configure("-DARCH=amd64", "-DCMAKE_BUILD_TYPE=Release"))
+Build_GCCLin_x64_Release.addStep(bs_bootcd)
+Build_GCCLin_x64_Release.addStep(bs_livecd)
+Build_GCCLin_x64_Release.addStep(bs_upload_iso)
+
 Build_GCCWin_x86 = util.BuildFactory();
 Build_GCCWin_x86.addStep(bs_clean)
 Build_GCCWin_x86.addStep(bs_git)
@@ -265,6 +286,14 @@ Build_GCCWin_x86.addStep(bs_prepare_source)
 Build_GCCWin_x86.addStep(make_bs_configure("-DENABLE_ROSAPPS=1", "-DENABLE_ROSTESTS=1"))
 Build_GCCWin_x86.addStep(bs_bootcd)
 Build_GCCWin_x86.addStep(bs_livecd)
+
+Build_GCCWin_x64 = util.BuildFactory();
+Build_GCCWin_x64.addStep(bs_clean)
+Build_GCCWin_x64.addStep(bs_git)
+Build_GCCWin_x64.addStep(bs_prepare_source)
+Build_GCCWin_x64.addStep(make_bs_configure("-DARCH=amd64", "-DENABLE_ROSAPPS=1", "-DENABLE_ROSTESTS=1"))
+Build_GCCWin_x64.addStep(bs_bootcd)
+Build_GCCWin_x64.addStep(bs_livecd)
 
 Build_MSVC_x86 = util.BuildFactory();
 Build_MSVC_x86.addStep(bs_clean)
@@ -348,11 +377,29 @@ c['builders'] = [
         builddir="Build_GCCLin_x86_Release",
         factory=Build_GCCLin_x86_Release),
     util.BuilderConfig(
+        name="Build GCCLin_x64",
+        properties={"rosbe": "2.2-Unix", "arch": "amd64"},
+        workernames=["Carrier"],
+        builddir="Build_GCCLin_x64",
+        factory=Build_GCCLin_x64),
+    util.BuilderConfig(
+        name="Build GCCLin_x64 Release",
+        properties={"rosbe": "2.2-Unix", "arch": "amd64"},
+        workernames=["Carrier"],
+        builddir="Build_GCCLin_x64_Release",
+        factory=Build_GCCLin_x64_Release),
+    util.BuilderConfig(
         name="Build GCCWin_x86",
         properties={"rosbe": "2.2.0-Win", "arch": "i686"},
         workernames=["Carrier-Win7"],
         builddir="Build_GCCWin_x86",
         factory=Build_GCCWin_x86),
+    util.BuilderConfig(
+        name="Build GCCWin_x64",
+        properties={"rosbe": "2.2.0-Win", "arch": "amd64"},
+        workernames=["Carrier-Win7"],
+        builddir="Build_GCCWin_x64",
+        factory=Build_GCCWin_x64),
     util.BuilderConfig(
         name="Build MSVC_x86",
         properties={"rosbe": "2.2.0-Win", "arch": "i686"},


### PR DESCRIPTION
Since GCC amd64 target is now compiling successfully in master, and even the appropriate checks were added to GitHub, it definitely makes sense to do that.