### PR TITLE
[MASTER] Add x86 and x64 builders/testers for `-DSAFE_TESTS_ONLY=1`

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -237,6 +237,17 @@ def make_bs_configure(*args):
         extract_fn=extract_build_props
     )
 
+def make_bs_regtestcd(*args):
+    cmd = ["bash", scripts_root + "regtestcd"] + list(args)
+
+    return steps.Compile(
+        name="regtestcd",
+        command=cmd,
+        warningPattern="^(.*warning[: ].*|.*error[: ].*)",
+        description=["TestCD"],
+        descriptionDone=["TestCD"]
+    )
+
 Build_GCCLin_x86 = util.BuildFactory();
 Build_GCCLin_x86.addStep(bs_clean)
 Build_GCCLin_x86.addStep(bs_git)
@@ -244,7 +255,7 @@ Build_GCCLin_x86.addStep(bs_prepare_source)
 Build_GCCLin_x86.addStep(make_bs_configure())
 Build_GCCLin_x86.addStep(bs_bootcd)
 Build_GCCLin_x86.addStep(bs_livecd)
-Build_GCCLin_x86.addStep(steps.Compile(name="regtestcd", command=["bash", scripts_root + "regtestcd", "-DENABLE_ROSTESTS=1"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["TestCD"], descriptionDone=["TestCD"]))
+Build_GCCLin_x86.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1"))
 Build_GCCLin_x86.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
 Build_GCCLin_x86.addStep(steps.Trigger(schedulerNames=['Carrier Testbot Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
 Build_GCCLin_x86.addStep(bs_upload_iso)
@@ -285,7 +296,7 @@ Build_MSVC_x64.addStep(bs_livecd)
 Build_MSVC_x64.addStep(steps.Compile(name="rostests", command=["bash", scripts_root + "build_rostests"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["rostests"], descriptionDone=["rostests"]))
 Build_MSVC_x64.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
 Build_MSVC_x64.addStep(steps.Trigger(schedulerNames=['Carrier-Win2003-x64 Testbot Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
-Build_MSVC_x64.addStep(steps.Compile(name="regtestcd", command=["bash", scripts_root + "regtestcd", "-DENABLE_ROSTESTS:BOOL=TRUE", "-D_WINKD_:BOOL=FALSE", "-DKDBG:BOOL=TRUE"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["TestCD"], descriptionDone=["TestCD"]))
+Build_MSVC_x64.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-D_WINKD_=0", "-DKBG=1"))
 Build_MSVC_x64.addStep(steps.Trigger(schedulerNames=['Carrier Testbot-x64 Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
 Build_MSVC_x64.addStep(bs_upload_iso)
 
@@ -303,7 +314,7 @@ Test_KVM_AHK.addStep(bs_git)
 Test_KVM_AHK.addStep(steps.ShellCommand(name="prepare ahk", command=["bash", scripts_root + "prepare_ahk"], description=["preparing ahk"], descriptionDone=["prepared ahk"], haltOnFailure=True))
 Test_KVM_AHK.addStep(bs_prepare_source)
 Test_KVM_AHK.addStep(steps.ShellCommand(name="compile ahk", command=["bash", "modules/AHK_Tests/compile.sh"], description=["compiling ahk"], descriptionDone=["compiled ahk"], haltOnFailure=True))
-Test_KVM_AHK.addStep(steps.Compile(name="regtestcd", command=["bash", scripts_root + "regtestcd"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["TestCD"], descriptionDone=["TestCD"]))
+Test_KVM_AHK.addStep(make_bs_regtestcd())
 Test_KVM_AHK.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
 Test_KVM_AHK.addStep(bs_submit_results)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -308,15 +308,15 @@ Test_KVM_x64 = util.BuildFactory();
 Test_KVM_x64.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
 Test_KVM_x64.addStep(bs_submit_results)
 
-Test_KVM_AHK = util.BuildFactory();
-Test_KVM_AHK.addStep(bs_clean)
-Test_KVM_AHK.addStep(bs_git)
-Test_KVM_AHK.addStep(steps.ShellCommand(name="prepare ahk", command=["bash", scripts_root + "prepare_ahk"], description=["preparing ahk"], descriptionDone=["prepared ahk"], haltOnFailure=True))
-Test_KVM_AHK.addStep(bs_prepare_source)
-Test_KVM_AHK.addStep(steps.ShellCommand(name="compile ahk", command=["bash", "modules/AHK_Tests/compile.sh"], description=["compiling ahk"], descriptionDone=["compiled ahk"], haltOnFailure=True))
-Test_KVM_AHK.addStep(make_bs_regtestcd())
-Test_KVM_AHK.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
-Test_KVM_AHK.addStep(bs_submit_results)
+#Test_KVM_AHK = util.BuildFactory();
+#Test_KVM_AHK.addStep(bs_clean)
+#Test_KVM_AHK.addStep(bs_git)
+#Test_KVM_AHK.addStep(steps.ShellCommand(name="prepare ahk", command=["bash", scripts_root + "prepare_ahk"], description=["preparing ahk"], descriptionDone=["prepared ahk"], haltOnFailure=True))
+#Test_KVM_AHK.addStep(bs_prepare_source)
+#Test_KVM_AHK.addStep(steps.ShellCommand(name="compile ahk", command=["bash", "modules/AHK_Tests/compile.sh"], description=["compiling ahk"], descriptionDone=["compiled ahk"], haltOnFailure=True))
+#Test_KVM_AHK.addStep(make_bs_regtestcd())
+#Test_KVM_AHK.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+#Test_KVM_AHK.addStep(bs_submit_results)
 
 Test_VBox = util.BuildFactory();
 Test_VBox.addStep(steps.ShellCommand(name="vbox_clean", command=["bash", scripts_root + "vbox_clean"], description=["cleaning VirtualBox"], descriptionDone=["cleaned VirtualBox"], haltOnFailure=True))

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -155,7 +155,6 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
     change_filter=util.ChangeFilter(branch='refs/heads/master'),
     treeStableTimer=None,
     builderNames=["Build GCCLin_x86", "Build MSVC_x86", "Build MSVC_x64"]))
-    #builderNames=["Build GCCLin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK"]))
 
 c['schedulers'].append(schedulers.SingleBranchScheduler(
     name="rostests",
@@ -196,7 +195,6 @@ c['schedulers'].append(schedulers.ForceScheduler(
         util.StringParameter(name="id", label="JIRA Patch ID:")
     ])],
     builderNames=["Build GCCLin_x86", "Build GCCWin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test WHS"]))
-    #builderNames=["Build GCCLin_x86", "Build GCCWin_x86", "Build MSVC_x86", "Build MSVC_x64", "Test KVM AHK", "Test WHS"]))
 
 ####### BUILDERS
 
@@ -361,30 +359,10 @@ Test_KVM_x64_Safe = util.BuildFactory();
 Test_KVM_x64_Safe.addStep(make_bs_regtest("sudo"))
 Test_KVM_x64_Safe.addStep(bs_submit_results)
 
-#Test_KVM_AHK = util.BuildFactory();
-#Test_KVM_AHK.addStep(bs_clean)
-#Test_KVM_AHK.addStep(bs_git)
-#Test_KVM_AHK.addStep(steps.ShellCommand(name="prepare ahk", command=["bash", scripts_root + "prepare_ahk"], description=["preparing ahk"], descriptionDone=["prepared ahk"], haltOnFailure=True))
-#Test_KVM_AHK.addStep(bs_prepare_source)
-#Test_KVM_AHK.addStep(steps.ShellCommand(name="compile ahk", command=["bash", "modules/AHK_Tests/compile.sh"], description=["compiling ahk"], descriptionDone=["compiled ahk"], haltOnFailure=True))
-#Test_KVM_AHK.addStep(make_bs_regtestcd())
-#Test_KVM_AHK.addStep(make_bs_regtest("sudo"))
-#Test_KVM_AHK.addStep(bs_submit_results)
-
 Test_VBox = util.BuildFactory();
 Test_VBox.addStep(steps.ShellCommand(name="vbox_clean", command=["bash", scripts_root + "vbox_clean"], description=["cleaning VirtualBox"], descriptionDone=["cleaned VirtualBox"], haltOnFailure=True))
 Test_VBox.addStep(make_bs_regtest())
 Test_VBox.addStep(bs_submit_results)
-
-#Test_VMW = util.BuildFactory();
-#Test_VMW.addStep(steps.ShellCommand(name="vmware_clean", command=["bash", scripts_root + "vmware_clean"], description=["cleaning VMware"], descriptionDone=["cleaned VMware"], haltOnFailure=True))
-#Test_VMW.addStep(bs_regtest)
-#Test_VMW.addStep(bs_submit_results)
-
-#Test_VMW_Hybrid = util.BuildFactory();
-#Test_VMW_Hybrid.addStep(steps.ShellCommand(name="vmware_clean", command=["bash", scripts_root + "vmware_clean"], description=["cleaning VMware"], descriptionDone=["cleaned VMware"], haltOnFailure=True))
-#Test_VMW_Hybrid.addStep(bs_regtest)
-#Test_VMW_Hybrid.addStep(bs_submit_results)
 
 Test_Win2003_x64 = util.BuildFactory();
 Test_Win2003_x64.addStep(bs_run_rostests)
@@ -446,9 +424,6 @@ c['builders'] = [
     util.BuilderConfig(name="Test KVM Safe", workernames=["Carrier"], builddir="Test_KVM_Safe", factory=Test_KVM_Safe),
     util.BuilderConfig(name="Test KVM_x64", workernames=["Carrier"], builddir="Test_KVM_x64", factory=Test_KVM_x64),
     util.BuilderConfig(name="Test KVM_x64 Safe", workernames=["Carrier"], builddir="Test_KVM_x64_Safe", factory=Test_KVM_x64_Safe),
-    #util.BuilderConfig(name="Test KVM AHK", workernames=["AHK-Bot"], builddir="Test_KVM_AHK", factory=Test_KVM_AHK),
-    #util.BuilderConfig(name="Test VMW", workernames=["Fezile"], builddir="Test_VMW", factory=Test_VMW),
-    #util.BuilderConfig(name="Test VMW Hybrid", workernames=["Fezile"], builddir="Test_VMW_Hybrid", factory=Test_VMW_Hybrid),
     util.BuilderConfig(name="Test Win2003_x64", workernames=["Carrier-Win2003-x64"], builddir="Test_Win2003_x64", factory=Test_Win2003_x64),
     util.BuilderConfig(name="Test WHS", workernames=["Carrier-WHS-Bot"], builddir="Test_WHS", factory=Test_WHS),
     util.BuilderConfig(name="Test VBox", workernames=["Testee"], builddir="Test_VBox", factory=Test_VBox),
@@ -474,19 +449,6 @@ c['services'] = [
             'failure': 1
         }
     ),
-#    reporters.MailNotifier(
-#        fromaddr="buildbot@reactos.org",
-#        sendToInterestedUsers=False,
-#        extraRecipients=["ros-builds@reactos.org"],
-#        mode='failing',
-#        subject="%(builder)s: build failed",
-#        builders=["Build GCCLin_x86", "Build GCCLin_x86 Release", "Test KVM", "Test VMW", "Test VMW Hybrid", "Build GCCWin_x86", "Build MSVC_x86", "Build MSVC2010_x86", "Test WHS", "Test VBox"],
-#        smtpPassword=credentials.get("mail", "passwd"),
-#        smtpUser=credentials.get("mail", "user"),
-#        useTls=True,
-#        relayhost="iserv.reactos.org",
-#        smtpPort=587
-#    ),
     reporters.GitHubStatusPush(
         token=credentials.get("github", "bbtoken")
     ),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -164,17 +164,16 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
     builderNames=["Test WHS"]))
 
 c['schedulers'].append(schedulers.Triggerable(
-    name="Carrier Testbot Trigger",
+    name="Build GCCLin_x86 regtestcd done",
     builderNames=["Test KVM", "Test VBox"]))
-    #builderNames=["Test KVM", "Test VMW", "Test VMW Hybrid", "Test VBox"]))
 
 c['schedulers'].append(schedulers.Triggerable(
-    name="Carrier Testbot-x64 Trigger",
-    builderNames=["Test KVM_x64"]))
-
-c['schedulers'].append(schedulers.Triggerable(
-    name="Carrier-Win2003-x64 Testbot Trigger",
+    name="Build MSVC_x64 rostests done",
     builderNames=["Test Win2003_x64"]))
+
+c['schedulers'].append(schedulers.Triggerable(
+    name="Build MSVC_x64 regtestcd done",
+    builderNames=["Test KVM_x64"]))
 
 c['schedulers'].append(schedulers.Periodic(
     name="Daily",
@@ -279,7 +278,7 @@ Build_GCCLin_x86.addStep(bs_bootcd)
 Build_GCCLin_x86.addStep(bs_livecd)
 Build_GCCLin_x86.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1"))
 Build_GCCLin_x86.addStep(bs_get_suffix)
-Build_GCCLin_x86.addStep(make_bs_trigger("Carrier Testbot Trigger"))
+Build_GCCLin_x86.addStep(make_bs_trigger("Build GCCLin_x86 regtestcd done"))
 Build_GCCLin_x86.addStep(bs_upload_iso)
 
 Build_GCCLin_x86_Release = util.BuildFactory();
@@ -317,9 +316,9 @@ Build_MSVC_x64.addStep(bs_bootcd)
 Build_MSVC_x64.addStep(bs_livecd)
 Build_MSVC_x64.addStep(bs_build_rostests)
 Build_MSVC_x64.addStep(bs_get_suffix)
-Build_MSVC_x64.addStep(make_bs_trigger("Carrier-Win2003-x64 Testbot Trigger"))
+Build_MSVC_x64.addStep(make_bs_trigger("Build MSVC_x64 rostests done"))
 Build_MSVC_x64.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-D_WINKD_=0", "-DKBG=1"))
-Build_MSVC_x64.addStep(make_bs_trigger("Carrier Testbot-x64 Trigger"))
+Build_MSVC_x64.addStep(make_bs_trigger("Build MSVC_x64 regtestcd done"))
 Build_MSVC_x64.addStep(bs_upload_iso)
 
 Test_KVM = util.BuildFactory();

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -165,7 +165,11 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
 
 c['schedulers'].append(schedulers.Triggerable(
     name="Build GCCLin_x86 regtestcd done",
-    builderNames=["Test KVM", "Test VBox"]))
+    builderNames=["Build GCCLin_x86 Safe", "Test KVM", "Test VBox"]))
+
+c['schedulers'].append(schedulers.Triggerable(
+    name="Build GCCLin_x86 Safe regtestcd done",
+    builderNames=["Test KVM Safe"]))
 
 c['schedulers'].append(schedulers.Triggerable(
     name="Build MSVC_x64 rostests done",
@@ -174,6 +178,10 @@ c['schedulers'].append(schedulers.Triggerable(
 c['schedulers'].append(schedulers.Triggerable(
     name="Build MSVC_x64 regtestcd done",
     builderNames=["Test KVM_x64"]))
+
+c['schedulers'].append(schedulers.Triggerable(
+    name="Build MSVC_x64 Safe regtestcd done",
+    builderNames=["Test KVM_x64 Safe"]))
 
 c['schedulers'].append(schedulers.Periodic(
     name="Daily",
@@ -290,6 +298,14 @@ Build_GCCLin_x86_Release.addStep(bs_bootcd)
 Build_GCCLin_x86_Release.addStep(bs_livecd)
 Build_GCCLin_x86_Release.addStep(bs_upload_iso)
 
+Build_GCCLin_x86_Safe = util.BuildFactory();
+Build_GCCLin_x86_Safe.addStep(bs_clean)
+Build_GCCLin_x86_Safe.addStep(bs_git)
+Build_GCCLin_x86_Safe.addStep(bs_prepare_source)
+Build_GCCLin_x86_Safe.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-DSAFE_TESTS_ONLY=1"))
+Build_GCCLin_x86_Safe.addStep(bs_get_suffix)
+Build_GCCLin_x86_Safe.addStep(make_bs_trigger("Build GCCLin_x86 Safe regtestcd done"))
+
 Build_GCCWin_x86 = util.BuildFactory();
 Build_GCCWin_x86.addStep(bs_clean)
 Build_GCCWin_x86.addStep(bs_git)
@@ -321,13 +337,29 @@ Build_MSVC_x64.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-D_WINKD_=0", "
 Build_MSVC_x64.addStep(make_bs_trigger("Build MSVC_x64 regtestcd done"))
 Build_MSVC_x64.addStep(bs_upload_iso)
 
+Build_MSVC_x64_Safe = util.BuildFactory();
+Build_MSVC_x64_Safe.addStep(bs_clean)
+Build_MSVC_x64_Safe.addStep(bs_git)
+Build_MSVC_x64_Safe.addStep(bs_prepare_source)
+Build_MSVC_x64_Safe.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-D_WINKD_=0", "-DKBG=1", "-DSAFE_TESTS_ONLY=1"))
+Build_MSVC_x64_Safe.addStep(bs_get_suffix)
+Build_MSVC_x64_Safe.addStep(make_bs_trigger("Build MSVC_x64 Safe regtestcd done"))
+
 Test_KVM = util.BuildFactory();
 Test_KVM.addStep(make_bs_regtest("sudo"))
 Test_KVM.addStep(bs_submit_results)
 
+Test_KVM_Safe = util.BuildFactory();
+Test_KVM_Safe.addStep(make_bs_regtest("sudo"))
+Test_KVM_Safe.addStep(bs_submit_results)
+
 Test_KVM_x64 = util.BuildFactory();
 Test_KVM_x64.addStep(make_bs_regtest("sudo"))
 Test_KVM_x64.addStep(bs_submit_results)
+
+Test_KVM_x64_Safe = util.BuildFactory();
+Test_KVM_x64_Safe.addStep(make_bs_regtest("sudo"))
+Test_KVM_x64_Safe.addStep(bs_submit_results)
 
 #Test_KVM_AHK = util.BuildFactory();
 #Test_KVM_AHK.addStep(bs_clean)
@@ -380,6 +412,12 @@ c['builders'] = [
         builddir="Build_GCCLin_x86_Release",
         factory=Build_GCCLin_x86_Release),
     util.BuilderConfig(
+        name="Build GCCLin_x86 Safe",
+        properties={"rosbe": "2.2-Unix", "arch": "i686"},
+        workernames=["Carrier"],
+        builddir="Build_GCCLin_x86_Safe",
+        factory=Build_GCCLin_x86_Safe),
+    util.BuilderConfig(
         name="Build GCCWin_x86",
         properties={"rosbe": "2.2.0-Win", "arch": "i686"},
         workernames=["Carrier-Win7"],
@@ -397,9 +435,17 @@ c['builders'] = [
         workernames=["Carrier-Win7"],
         builddir="Build_MSVC_x64",
         factory=Build_MSVC_x64),
+    util.BuilderConfig(
+        name="Build MSVC_x64 Safe",
+        properties={"rosbe": "2.2.0-Win", "arch": "amd64"},
+        workernames=["Carrier-Win7"],
+        builddir="Build_MSVC_x64_Safe",
+        factory=Build_MSVC_x64_Safe),
 
     util.BuilderConfig(name="Test KVM", workernames=["Carrier"], builddir="Test_KVM", factory=Test_KVM),
+    util.BuilderConfig(name="Test KVM Safe", workernames=["Carrier"], builddir="Test_KVM_Safe", factory=Test_KVM_Safe),
     util.BuilderConfig(name="Test KVM_x64", workernames=["Carrier"], builddir="Test_KVM_x64", factory=Test_KVM_x64),
+    util.BuilderConfig(name="Test KVM_x64 Safe", workernames=["Carrier"], builddir="Test_KVM_x64_Safe", factory=Test_KVM_x64_Safe),
     #util.BuilderConfig(name="Test KVM AHK", workernames=["AHK-Bot"], builddir="Test_KVM_AHK", factory=Test_KVM_AHK),
     #util.BuilderConfig(name="Test VMW", workernames=["Fezile"], builddir="Test_VMW", factory=Test_VMW),
     #util.BuilderConfig(name="Test VMW Hybrid", workernames=["Fezile"], builddir="Test_VMW_Hybrid", factory=Test_VMW_Hybrid),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -248,6 +248,18 @@ def make_bs_regtestcd(*args):
         descriptionDone=["TestCD"]
     )
 
+def make_bs_regtest(*prepended_args):
+    cmd = list(prepended_args) + ["bash", scripts_root + "regtest", util.WithProperties('%(suffix)s')]
+
+    return steps.Compile(
+        name="test",
+        command=cmd,
+        warningPattern=".*[:] Test .*",
+        description=["testing"],
+        descriptionDone=["test"]
+    )
+
+
 Build_GCCLin_x86 = util.BuildFactory();
 Build_GCCLin_x86.addStep(bs_clean)
 Build_GCCLin_x86.addStep(bs_git)
@@ -301,11 +313,11 @@ Build_MSVC_x64.addStep(steps.Trigger(schedulerNames=['Carrier Testbot-x64 Trigge
 Build_MSVC_x64.addStep(bs_upload_iso)
 
 Test_KVM = util.BuildFactory();
-Test_KVM.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+Test_KVM.addStep(make_bs_regtest("sudo"))
 Test_KVM.addStep(bs_submit_results)
 
 Test_KVM_x64 = util.BuildFactory();
-Test_KVM_x64.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+Test_KVM_x64.addStep(make_bs_regtest("sudo"))
 Test_KVM_x64.addStep(bs_submit_results)
 
 #Test_KVM_AHK = util.BuildFactory();
@@ -315,12 +327,12 @@ Test_KVM_x64.addStep(bs_submit_results)
 #Test_KVM_AHK.addStep(bs_prepare_source)
 #Test_KVM_AHK.addStep(steps.ShellCommand(name="compile ahk", command=["bash", "modules/AHK_Tests/compile.sh"], description=["compiling ahk"], descriptionDone=["compiled ahk"], haltOnFailure=True))
 #Test_KVM_AHK.addStep(make_bs_regtestcd())
-#Test_KVM_AHK.addStep(steps.Compile(name="test", command=["sudo", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+#Test_KVM_AHK.addStep(make_bs_regtest("sudo"))
 #Test_KVM_AHK.addStep(bs_submit_results)
 
 Test_VBox = util.BuildFactory();
 Test_VBox.addStep(steps.ShellCommand(name="vbox_clean", command=["bash", scripts_root + "vbox_clean"], description=["cleaning VirtualBox"], descriptionDone=["cleaned VirtualBox"], haltOnFailure=True))
-Test_VBox.addStep(steps.Compile(name="test", command=["bash", scripts_root + "regtest", util.WithProperties('%(suffix)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+Test_VBox.addStep(make_bs_regtest())
 Test_VBox.addStep(bs_submit_results)
 
 #Test_VMW = util.BuildFactory();

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -204,8 +204,11 @@ bs_clean = steps.ShellCommand(name="clean", command=["bash", scripts_root + "cle
 bs_prepare_source = steps.ShellCommand(name="prepare_source", command=["bash", scripts_root + "prepare_source", util.WithProperties("%(id:-)s")], description=["preparing source"], descriptionDone=["prepared source"], haltOnFailure=True)
 bs_bootcd = steps.Compile(name="bootcd", command=["bash", scripts_root + "build_reactos", "bootcd"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["BootCD"], descriptionDone=["BootCD"])
 bs_livecd = steps.Compile(name="livecd", command=["bash", scripts_root + "build_reactos", "livecd"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["LiveCD"], descriptionDone=["LiveCD"])
+bs_get_suffix = steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix")
 bs_upload_iso = steps.ShellCommand(name="uploadiso", command=["bash", scripts_root + "uploadiso"], description=["uploading"], descriptionDone=["uploaded"])
 bs_submit_results = steps.ShellCommand(name="submit_results", command=["bash", scripts_root + "submit_result", util.WithProperties('%(buildnumber)s'), util.WithProperties('%(reason:-)s'), util.WithProperties('%(id:-)s')], description=["submitting results"], descriptionDone=["submit results"])
+bs_build_rostests = steps.Compile(name="rostests", command=["bash", scripts_root + "build_rostests"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["rostests"], descriptionDone=["rostests"])
+bs_run_rostests = steps.Compile(name="test", command=["bash", scripts_root + "run_rostests", util.WithProperties('%(suffix)s'), util.WithProperties('%(buildnumber)s'), util.WithProperties('%(reason:-)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"])
 
 compiler_re = re.compile("\-\- The C compiler identification is (GNU|MSVC) ([\.\d]+)")
 build_type_re = re.compile("\-\- Build Type\: (Debug|Release)")
@@ -259,6 +262,13 @@ def make_bs_regtest(*prepended_args):
         descriptionDone=["test"]
     )
 
+def make_bs_trigger(name):
+    return steps.Trigger(
+        schedulerNames=[name],
+        waitForFinish=False,
+        copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']
+    )
+
 
 Build_GCCLin_x86 = util.BuildFactory();
 Build_GCCLin_x86.addStep(bs_clean)
@@ -268,8 +278,8 @@ Build_GCCLin_x86.addStep(make_bs_configure())
 Build_GCCLin_x86.addStep(bs_bootcd)
 Build_GCCLin_x86.addStep(bs_livecd)
 Build_GCCLin_x86.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1"))
-Build_GCCLin_x86.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
-Build_GCCLin_x86.addStep(steps.Trigger(schedulerNames=['Carrier Testbot Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
+Build_GCCLin_x86.addStep(bs_get_suffix)
+Build_GCCLin_x86.addStep(make_bs_trigger("Carrier Testbot Trigger"))
 Build_GCCLin_x86.addStep(bs_upload_iso)
 
 Build_GCCLin_x86_Release = util.BuildFactory();
@@ -305,11 +315,11 @@ Build_MSVC_x64.addStep(bs_prepare_source)
 Build_MSVC_x64.addStep(make_bs_configure())
 Build_MSVC_x64.addStep(bs_bootcd)
 Build_MSVC_x64.addStep(bs_livecd)
-Build_MSVC_x64.addStep(steps.Compile(name="rostests", command=["bash", scripts_root + "build_rostests"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["rostests"], descriptionDone=["rostests"]))
-Build_MSVC_x64.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
-Build_MSVC_x64.addStep(steps.Trigger(schedulerNames=['Carrier-Win2003-x64 Testbot Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
+Build_MSVC_x64.addStep(bs_build_rostests)
+Build_MSVC_x64.addStep(bs_get_suffix)
+Build_MSVC_x64.addStep(make_bs_trigger("Carrier-Win2003-x64 Testbot Trigger"))
 Build_MSVC_x64.addStep(make_bs_regtestcd("-DENABLE_ROSTESTS=1", "-D_WINKD_=0", "-DKBG=1"))
-Build_MSVC_x64.addStep(steps.Trigger(schedulerNames=['Carrier Testbot-x64 Trigger'], waitForFinish=False, copy_properties=['got_revision', 'id', 'owners', 'reason', 'suffix']))
+Build_MSVC_x64.addStep(make_bs_trigger("Carrier Testbot-x64 Trigger"))
 Build_MSVC_x64.addStep(bs_upload_iso)
 
 Test_KVM = util.BuildFactory();
@@ -346,15 +356,15 @@ Test_VBox.addStep(bs_submit_results)
 #Test_VMW_Hybrid.addStep(bs_submit_results)
 
 Test_Win2003_x64 = util.BuildFactory();
-Test_Win2003_x64.addStep(steps.Compile(name="test", command=["bash", scripts_root + "run_rostests", util.WithProperties('%(suffix)s'), util.WithProperties('%(buildnumber)s'), util.WithProperties('%(reason:-)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+Test_Win2003_x64.addStep(bs_run_rostests)
 
 Test_WHS = util.BuildFactory();
 Test_WHS.addStep(bs_clean)
 Test_WHS.addStep(bs_git)
 Test_WHS.addStep(bs_prepare_source)
-Test_WHS.addStep(steps.Compile(name="rostests", command=["bash", scripts_root + "build_rostests"], warningPattern="^(.*warning[: ].*|.*error[: ].*)", description=["rostests"], descriptionDone=["rostests"]))
-Test_WHS.addStep(steps.SetPropertyFromCommand(command=["bash", scripts_root + "get_suffix"], property="suffix"))
-Test_WHS.addStep(steps.Compile(name="test", command=["bash", scripts_root + "run_rostests", util.WithProperties('%(suffix)s'), util.WithProperties('%(buildnumber)s'), util.WithProperties('%(reason:-)s')], warningPattern=".*[:] Test .*", description=["testing"], descriptionDone=["test"]))
+Test_WHS.addStep(bs_build_rostests)
+Test_WHS.addStep(bs_get_suffix)
+Test_WHS.addStep(bs_run_rostests)
 
 
 c['builders'] = [


### PR DESCRIPTION
As requested by @tkreuzer, here comes an extra tester for a rostests build with `-DSAFE_TESTS_ONLY=1`.
This allows @tkreuzer to implement a list of safe tests in the main repo and only run these (without crash recovery).

Next to the testers, I needed to add an extra builder for x86 and x64.
This is necessary, because:
* The x64 builder is a Windows MSVC builder, but the x64 tester is a Linux server with KVM. This is why we can't have a combined builder/tester for x64 (and I did it the same for x86 for consistency).
* We can't just add another step to the existing x86/x64 builders, because we need to transfer the bootcdregtest to the tester after build. They are distinguished via their suffix, and there can only be one suffix per builder.

I took the opportunity to clean up our BuildBot master.cfg, deduplicate lots of copy-pastes, and remove commented out and long obsoleted configs.
Therefore, this PR is best to be reviewed commit by commit.