### PR TITLE
[MASTER] Cleanup password examples in the credentials.ini template file

### DIFF
--- a/master/credentials.ini
+++ b/master/credentials.ini
@@ -20,11 +20,8 @@ passwd=XXXXX
 webhookurl=XXXXX
 
 [workers]
-AHK-Bot_passwd=XXXXX
-Carrier-GCC8_passwd=XXXXX
-Carrier-WHS-Bot_passwd=XXXXX
-Carrier-Win2003-x64_passwd=XXXXX
-Carrier-Win7_passwd=XXXXX
-Fezile_passwd=XXXXX
-HotelLux_passwd=XXXXX
+Phoenix_passwd=XXXXX
+Phoenix-WHS-Bot_passwd=XXXXX
+Phoenix-Win2003-x64_passwd=XXXXX
+Phoenix-Win7_passwd=XXXXX
 Testee_passwd=XXXXX


### PR DESCRIPTION
Cleanup the workers password examples, following commit ceab651008, where the Carrier bots were removed, and the Phoenix ones introduced.